### PR TITLE
use build-time arg so we can modify VITE_API_BASE_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:24-alpine AS build
 WORKDIR /app
 COPY package*.json ./
+ARG VITE_API_BASE_URL=/tictac/api/v1
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 RUN npm ci
 COPY . .
 RUN npm run build


### PR DESCRIPTION
Just adding a build-arg so we can make the `VITE_API_BASE_URL` something other than `/api/v1` (useful on server like habanero where we have multiple webapps running)