### PR TITLE
Increase API request limit to 5000

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -31,7 +31,7 @@ const Dashboard = () => {
         const rows = await fetchAssociationSummary({
           doid: diseaseId,
           gene_symbol: geneSymbol,
-          limit: 1000,
+          limit: 5000,
         });
         setData(rows);
       } catch {


### PR DESCRIPTION
Fixes #12 
Dashboard UI can now display up to 5000 results.